### PR TITLE
Applied `gofmt` to the code base

### DIFF
--- a/compact.go
+++ b/compact.go
@@ -9,11 +9,10 @@ import (
 	"unsafe"
 )
 
-
 //============================================= Mari Compact
 
-
 // newCompaction
+//
 //	Instatiate the compaction strategy on compaction signal.
 //	Creates a new temporary memory mapped file where the version to be snapshotted will be written to.
 func (mariInst *Mari) newCompaction(compactedVersion uint64) (*Compaction, error) {
@@ -22,29 +21,35 @@ func (mariInst *Mari) newCompaction(compactedVersion uint64) (*Compaction, error
 
 	flag := os.O_RDWR | os.O_CREATE | os.O_APPEND
 	tempFile, compactErr := os.OpenFile(tempFileName, flag, 0600)
-	if compactErr != nil { return nil, compactErr }
+	if compactErr != nil {
+		return nil, compactErr
+	}
 
-	compact := &Compaction{ 
-		tempFile: tempFile,
+	compact := &Compaction{
+		tempFile:         tempFile,
 		compactedVersion: compactedVersion,
 	}
 
 	compact.tempData.Store(MMap{})
 	compactErr = compact.resizeTempFile(0)
-	if compactErr != nil { return nil, compactErr }
+	if compactErr != nil {
+		return nil, compactErr
+	}
 	return compact, nil
 }
 
 // signalCompact
+//
 //	When the maximum version is reached, signal the compaction go routine
 func (mariInst *Mari) signalCompact() {
-	select { 
-		case mariInst.signalCompactChan <- true:
-		default:
+	select {
+	case mariInst.signalCompactChan <- true:
+	default:
 	}
 }
 
 // compactHandler
+//
 //	Run in a separate go routine.
 //	On signal, sets the resizing flag and acquires the write lock.
 //	The current root is loaded and then the elements are recursively written to the new file.
@@ -52,7 +57,9 @@ func (mariInst *Mari) signalCompact() {
 func (mariInst *Mari) compactHandler() {
 	for range mariInst.signalCompactChan {
 		cErr := func() error {
-			for ! atomic.CompareAndSwapUint32(&mariInst.isResizing, 0, 1) { runtime.Gosched() }
+			for !atomic.CompareAndSwapUint32(&mariInst.isResizing, 0, 1) {
+				runtime.Gosched()
+			}
 			defer atomic.StoreUint32(&mariInst.isResizing, 0)
 
 			mariInst.rwResizeLock.Lock()
@@ -60,64 +67,77 @@ func (mariInst *Mari) compactHandler() {
 
 			var compactErr error
 			_, rootOffset, compactErr := mariInst.loadMetaRootOffset()
-			if compactErr != nil { return compactErr }
-		
+			if compactErr != nil {
+				return compactErr
+			}
+
 			currRoot, compactErr := mariInst.readINodeFromMemMap(rootOffset)
-			if compactErr != nil { return compactErr }
-		
+			if compactErr != nil {
+				return compactErr
+			}
+
 			compact, compactErr := mariInst.newCompaction(currRoot.version)
-			if compactErr != nil { return compactErr }
-		
+			if compactErr != nil {
+				return compactErr
+			}
+
 			currRootPtr := storeINodeAsPointer(currRoot)
 			endOff, compactErr := mariInst.serializeCurrentVersionToNewFile(compact, currRootPtr, 0, 0, InitRootOffset)
-			if compactErr != nil { 
+			if compactErr != nil {
 				os.Remove(compact.tempFile.Name())
-				return compactErr 
+				return compactErr
 			}
-		
+
 			newMeta := &MetaData{
-				version: 0,
-				rootOffset: uint64(InitRootOffset),
+				version:         0,
+				rootOffset:      uint64(InitRootOffset),
 				nextStartOffset: endOff,
 			}
-		
+
 			serializedMeta := newMeta.serializeMetaData()
 			_, compactErr = compact.writeMetaToTempMemMap(serializedMeta)
-			if compactErr != nil { 
+			if compactErr != nil {
 				os.Remove(compact.tempFile.Name())
-				return compactErr 
+				return compactErr
 			}
-			
+
 			compactErr = mariInst.swapTempFileWithMari(compact)
-			if compactErr != nil { 
+			if compactErr != nil {
 				os.Remove(compact.tempFile.Name())
-				return compactErr 
+				return compactErr
 			}
 
 			return nil
 		}()
 
-		if cErr != nil { fmt.Println("error on compaction process:", cErr) }
+		if cErr != nil {
+			fmt.Println("error on compaction process:", cErr)
+		}
 	}
 }
 
 // serializeCurrentVersionToNewFile
+//
 //	Recursively builds the new copy of the current version to the new file.
 //	All previous unused paths are discarded.
 //	At each level, the nodes are directly written to the memory map as to avoid loading the entire structure into memory.
 func (mariInst *Mari) serializeCurrentVersionToNewFile(compact *Compaction, node *unsafe.Pointer, level int, version, offset uint64) (uint64, error) {
 	currNode := loadINodeFromPointer(node)
-	
+
 	currNode.version = version
 	currNode.startOffset = offset
 	currNode.leaf.version = version
 
 	var serializeErr error
 	sNode, serializeErr := currNode.serializeINode(true)
-	if serializeErr != nil { return 0, serializeErr }
+	if serializeErr != nil {
+		return 0, serializeErr
+	}
 
 	serializedKeyVal, serializeErr := currNode.leaf.serializeLNode()
-	if serializeErr != nil { return 0, serializeErr }
+	if serializeErr != nil {
+		return 0, serializeErr
+	}
 
 	nextStartOffset := currNode.leaf.getEndOffsetLNode() + 1
 
@@ -128,29 +148,36 @@ func (mariInst *Mari) serializeCurrentVersionToNewFile(compact *Compaction, node
 
 		for _, child := range currNode.children {
 			sNode = append(sNode, serializeUint64(nextStartOffset)...)
-	
+
 			childNode, serializeErr = mariInst.readINodeFromMemMap(child.startOffset)
-			if serializeErr != nil { return 0, serializeErr }
-	
+			if serializeErr != nil {
+				return 0, serializeErr
+			}
+
 			childPtr = storeINodeAsPointer(childNode)
-			updatedOffset, serializeErr = mariInst.serializeCurrentVersionToNewFile(compact, childPtr, level + 1, version, nextStartOffset)
-			if serializeErr != nil { return 0, serializeErr }
-	
+			updatedOffset, serializeErr = mariInst.serializeCurrentVersionToNewFile(compact, childPtr, level+1, version, nextStartOffset)
+			if serializeErr != nil {
+				return 0, serializeErr
+			}
+
 			nextStartOffset = updatedOffset
 		}
 	}
 
 	serializeErr = compact.resizeTempFile(currNode.leaf.getEndOffsetLNode() + 1)
-	if serializeErr != nil { return 0, serializeErr }
+	if serializeErr != nil {
+		return 0, serializeErr
+	}
 
 	sNode = append(sNode, serializedKeyVal...)
 
 	temp := compact.tempData.Load().(MMap)
-	copy(temp[currNode.startOffset:currNode.leaf.getEndOffsetLNode() + 1], sNode)
+	copy(temp[currNode.startOffset:currNode.leaf.getEndOffsetLNode()+1], sNode)
 	return nextStartOffset, nil
 }
 
 // swapTempFileWithMari
+//
 //	Close the current mari memory mapped file and swap the new compacted copy.
 //	Rebuild the version index on compaction
 func (mariInst *Mari) swapTempFileWithMari(compact *Compaction) error {
@@ -160,17 +187,25 @@ func (mariInst *Mari) swapTempFileWithMari(compact *Compaction) error {
 
 	var swapErr error
 	swapErr = mariInst.Close()
-	if swapErr != nil { return swapErr }
+	if swapErr != nil {
+		return swapErr
+	}
 
 	swapErr = compact.tempFile.Sync()
-	if swapErr != nil { return swapErr }
+	if swapErr != nil {
+		return swapErr
+	}
 
 	swapErr = compact.munmapTemp()
-	if swapErr != nil { return swapErr }
+	if swapErr != nil {
+		return swapErr
+	}
 
 	swapErr = compact.tempFile.Close()
-	if swapErr != nil { return swapErr }
-	
+	if swapErr != nil {
+		return swapErr
+	}
+
 	os.Rename(currFileName, swapFileName)
 	os.Rename(tempFileName, currFileName)
 
@@ -178,85 +213,108 @@ func (mariInst *Mari) swapTempFileWithMari(compact *Compaction) error {
 
 	flag := os.O_RDWR | os.O_CREATE | os.O_APPEND
 	mariInst.file, swapErr = os.OpenFile(currFileName, flag, 0600)
-	if swapErr != nil { return swapErr }
+	if swapErr != nil {
+		return swapErr
+	}
 
 	swapErr = mariInst.mmap()
-	if swapErr != nil { return swapErr }
+	if swapErr != nil {
+		return swapErr
+	}
 	return nil
 }
 
-
 // mMapTemp
+//
 //	Mmap helper for the temporary memory mapped file.
 func (compact *Compaction) mMapTemp() error {
 	temp, tempErr := Map(compact.tempFile, RDWR, 0)
-	if tempErr != nil { return tempErr }
+	if tempErr != nil {
+		return tempErr
+	}
 
 	compact.tempData.Store(temp)
 	return nil
 }
 
 // munmapTemp
+//
 //	Unmap helper for the tempory memory mapped file
 func (compact *Compaction) munmapTemp() error {
 	temp := compact.tempData.Load().(MMap)
 	unmapErr := temp.Unmap()
-	if unmapErr != nil { return unmapErr }
+	if unmapErr != nil {
+		return unmapErr
+	}
 
 	compact.tempData.Store(MMap{})
 	return nil
 }
 
 // resizeTempFile
+//
 //	As the new copy is being built, the file will need to be resized as more elements are appended.
 //	Follow a similar strategy to the resizeFile method for the mari memory map.
 func (compact *Compaction) resizeTempFile(offset uint64) error {
 	temp := compact.tempData.Load().(MMap)
-	if offset > 0 && int(offset) < len(temp) { return nil }
-	
+	if offset > 0 && int(offset) < len(temp) {
+		return nil
+	}
+
 	allocateSize := func() int64 {
 		switch {
-			case len(temp) == 0:
-				return int64(DefaultPageSize) * 16 * 1000 // 64MB
-			case len(temp) >= MaxResize:
-				return int64(len(temp) + MaxResize)
-			default:
-				return int64(len(temp) * 2)
+		case len(temp) == 0:
+			return int64(DefaultPageSize) * 16 * 1000 // 64MB
+		case len(temp) >= MaxResize:
+			return int64(len(temp) + MaxResize)
+		default:
+			return int64(len(temp) * 2)
 		}
 	}()
 
 	var resizeErr error
 	if len(temp) > 0 {
 		resizeErr = compact.tempFile.Sync()
-		if resizeErr != nil { return resizeErr }
-		
+		if resizeErr != nil {
+			return resizeErr
+		}
+
 		resizeErr = compact.munmapTemp()
-		if resizeErr != nil { return resizeErr }
+		if resizeErr != nil {
+			return resizeErr
+		}
 	}
 
 	resizeErr = compact.tempFile.Truncate(allocateSize)
-	if resizeErr != nil { return resizeErr }
+	if resizeErr != nil {
+		return resizeErr
+	}
 
 	resizeErr = compact.mMapTemp()
-	if resizeErr != nil { return resizeErr }
+	if resizeErr != nil {
+		return resizeErr
+	}
 	return nil
 }
 
 // writeMetaToTempMemMap
+//
 //	Copy the serialized metadata into the memory map.
 func (compact *Compaction) writeMetaToTempMemMap(sMeta []byte) (ok bool, err error) {
 	defer func() {
 		r := recover()
-		if r != nil { 
+		if r != nil {
 			ok = false
 			err = errors.New("error writing metadata to mmap")
 		}
 	}()
 
 	temp := compact.tempData.Load().(MMap)
-	copy(temp[MetaVersionIdx:MetaEndSerializedOffset + OffsetSize64], sMeta)
+	copy(temp[MetaVersionIdx:MetaEndSerializedOffset+OffsetSize64], sMeta)
 
 	flushErr := compact.tempFile.Sync()
-	if flushErr != nil { return false, flushErr }
+	if flushErr != nil {
+		return false, flushErr
+	}
 	return true, nil
 }

--- a/io.go
+++ b/io.go
@@ -6,11 +6,10 @@ import (
 	"unsafe"
 )
 
-
 //============================================= Mari IO Utils
 
-
 // compareAndSwap
+//
 //	Performs CAS operation.
 func (mariInst *Mari) compareAndSwap(node *unsafe.Pointer, currNode, nodeCopy *INode) bool {
 	if atomic.CompareAndSwapPointer(node, unsafe.Pointer(currNode), unsafe.Pointer(nodeCopy)) {
@@ -23,42 +22,51 @@ func (mariInst *Mari) compareAndSwap(node *unsafe.Pointer, currNode, nodeCopy *I
 }
 
 // determineIfResize
+//
 //	Helper function that signals go routine for resizing if the condition to resize is met.
 func (mariInst *Mari) determineIfResize(offset uint64) bool {
 	mMap := mariInst.data.Load().(MMap)
 	switch {
-		case offset > 0 && int(offset) < len(mMap):
-			return false
-		case len(mMap) == 0 || ! atomic.CompareAndSwapUint32(&mariInst.isResizing, 0, 1):
-			return true
-		default:
-			mariInst.signalResizeChan <- true
-			return true
+	case offset > 0 && int(offset) < len(mMap):
+		return false
+	case len(mMap) == 0 || !atomic.CompareAndSwapUint32(&mariInst.isResizing, 0, 1):
+		return true
+	default:
+		mariInst.signalResizeChan <- true
+		return true
 	}
 }
 
 // flushRegionToDisk
-//	Flushes a region of the memory map to disk instead of flushing the entire map. 
+//
+//	Flushes a region of the memory map to disk instead of flushing the entire map.
 //	When a startoffset is provided, if it is not aligned with the start of the last page, the offset needs to be normalized.
 func (mariInst *Mari) flushRegionToDisk(startOffset, endOffset uint64) error {
 	startOffsetOfPage := startOffset & ^(uint64(DefaultPageSize) - 1)
 	mMap := mariInst.data.Load().(MMap)
-	if len(mMap) == 0 { return nil }
+	if len(mMap) == 0 {
+		return nil
+	}
 
 	flushErr := mMap[startOffsetOfPage:endOffset].Flush()
-	if flushErr != nil { return flushErr }
+	if flushErr != nil {
+		return flushErr
+	}
 
 	return nil
 }
 
 // handleFlush
-//	This is "optimistic" flushing. 
+//
+//	This is "optimistic" flushing.
 //	A separate go routine is spawned and signalled to flush changes to the mmap to disk.
 func (mariInst *Mari) handleFlush() {
 	for range mariInst.signalFlushChan {
 		func() {
-			for atomic.LoadUint32(&mariInst.isResizing) == 1 { runtime.Gosched() }
-			
+			for atomic.LoadUint32(&mariInst.isResizing) == 1 {
+				runtime.Gosched()
+			}
+
 			mariInst.rwResizeLock.RLock()
 			defer mariInst.rwResizeLock.RUnlock()
 
@@ -68,120 +76,152 @@ func (mariInst *Mari) handleFlush() {
 }
 
 // handleResize
+//
 //	A separate go routine is spawned to handle resizing the memory map.
 //	When the mmap reaches its size limit, the go routine is signalled.
 func (mariInst *Mari) handleResize() {
-	for range mariInst.signalResizeChan { mariInst.resizeMmap() }
+	for range mariInst.signalResizeChan {
+		mariInst.resizeMmap()
+	}
 }
 
 // mmap
+//
 //	Helper to memory map the mariInst File in to buffer.
 func (mariInst *Mari) mmap() error {
 	mMap, mmapErr := Map(mariInst.file, RDWR, 0)
-	if mmapErr != nil { return mmapErr }
+	if mmapErr != nil {
+		return mmapErr
+	}
 
 	mariInst.data.Store(mMap)
 	return nil
 }
 
 // munmap
+//
 //	Unmaps the memory map from RAM.
 func (mariInst *Mari) munmap() error {
 	mMap := mariInst.data.Load().(MMap)
 	unmapErr := mMap.Unmap()
-	if unmapErr != nil { return unmapErr }
+	if unmapErr != nil {
+		return unmapErr
+	}
 
 	mariInst.data.Store(MMap{})
 	return nil
 }
 
 // resizeMmap
+//
 //	Dynamically resizes the underlying memory mapped file.
 //	When a file is first created, default size is 64MB and doubles the mem map on each resize until 1GB.
 func (mariInst *Mari) resizeMmap() (bool, error) {
 	var resizeErr error
 	mariInst.rwResizeLock.Lock()
-	
+
 	defer mariInst.rwResizeLock.Unlock()
 	defer atomic.StoreUint32(&mariInst.isResizing, 0)
 
 	mMap := mariInst.data.Load().(MMap)
 	allocateSize := func() int64 {
 		switch {
-			case len(mMap) == 0:
-				return int64(DefaultPageSize) * 16 * 1000 // 64MB
-			case len(mMap) >= MaxResize:
-				return int64(len(mMap) + MaxResize)
-			default:
-				return int64(len(mMap) * 2)
+		case len(mMap) == 0:
+			return int64(DefaultPageSize) * 16 * 1000 // 64MB
+		case len(mMap) >= MaxResize:
+			return int64(len(mMap) + MaxResize)
+		default:
+			return int64(len(mMap) * 2)
 		}
 	}()
 
 	if len(mMap) > 0 {
 		resizeErr = mariInst.file.Sync()
-		if resizeErr != nil { return false, resizeErr }
-		
+		if resizeErr != nil {
+			return false, resizeErr
+		}
+
 		resizeErr = mariInst.munmap()
-		if resizeErr != nil { return false, resizeErr }
+		if resizeErr != nil {
+			return false, resizeErr
+		}
 	}
 
 	resizeErr = mariInst.file.Truncate(allocateSize)
-	if resizeErr != nil { return false, resizeErr }
+	if resizeErr != nil {
+		return false, resizeErr
+	}
 
 	resizeErr = mariInst.mmap()
-	if resizeErr != nil { return false, resizeErr }
+	if resizeErr != nil {
+		return false, resizeErr
+	}
 
 	return true, nil
 }
 
 // signalFlush
+//
 //	Called by all writes to "optimistically" handle flushing changes to the mmap to disk.
 func (mariInst *Mari) signalFlush() {
 	select {
-		case mariInst.signalFlushChan <- true:
-		default:
+	case mariInst.signalFlushChan <- true:
+	default:
 	}
 }
 
 // exclusiveWriteMmap
+//
 //	Takes a path copy and writes the nodes to the memory map, then updates the metadata.
 func (mariInst *Mari) exclusiveWriteMmap(path *INode) (bool, error) {
-	if atomic.LoadUint32(&mariInst.isResizing) == 1 { return false, nil }
+	if atomic.LoadUint32(&mariInst.isResizing) == 1 {
+		return false, nil
+	}
 
 	var writeErr error
 	versionPtr, version, writeErr := mariInst.loadMetaVersion()
-	if writeErr != nil { return false, nil }
+	if writeErr != nil {
+		return false, nil
+	}
 
 	rootOffsetPtr, prevRootOffset, writeErr := mariInst.loadMetaRootOffset()
-	if writeErr != nil { return false, nil }
+	if writeErr != nil {
+		return false, nil
+	}
 
 	endOffsetPtr, endOffset, writeErr := mariInst.loadMetaEndSerialized()
-	if writeErr != nil { return false, nil }
+	if writeErr != nil {
+		return false, nil
+	}
 
 	newVersion := path.version
 	newOffsetInMMap := endOffset
-	
+
 	serializedPath, writeErr := mariInst.serializePathToMemMap(path, newOffsetInMMap)
-	if writeErr != nil { return false, writeErr }
+	if writeErr != nil {
+		return false, writeErr
+	}
 
 	updatedMeta := &MetaData{
-		version: newVersion,
-		rootOffset: newOffsetInMMap,
+		version:         newVersion,
+		rootOffset:      newOffsetInMMap,
 		nextStartOffset: newOffsetInMMap + uint64(len(serializedPath)),
 	}
 
 	isResize := mariInst.determineIfResize(updatedMeta.nextStartOffset)
-	if isResize { return false, nil }
+	if isResize {
+		return false, nil
+	}
 
-	if ! mariInst.appendOnly && mariInst.compactTrigger(updatedMeta) {
+	if !mariInst.appendOnly && mariInst.compactTrigger(updatedMeta) {
 		mariInst.signalCompact()
 		return false, nil
 	}
-	
+
 	if atomic.LoadUint32(&mariInst.isResizing) == 0 {
-		if version == updatedMeta.version - 1 && atomic.CompareAndSwapUint64(versionPtr, version, updatedMeta.version) {
+		if version == updatedMeta.version-1 && atomic.CompareAndSwapUint64(versionPtr, version, updatedMeta.version) {
 			mariInst.storeMetaPointer(endOffsetPtr, updatedMeta.nextStartOffset)
-			
+
 			_, writeErr = mariInst.writeNodesToMemMap(serializedPath, newOffsetInMMap)
 			if writeErr != nil {
 				mariInst.storeMetaPointer(endOffsetPtr, endOffset)
@@ -190,7 +230,7 @@ func (mariInst *Mari) exclusiveWriteMmap(path *INode) (bool, error) {
 
 				return false, writeErr
 			}
-			
+
 			mariInst.storeMetaPointer(rootOffsetPtr, updatedMeta.rootOffset)
 			mariInst.signalFlush()
 

--- a/mari.go
+++ b/mari.go
@@ -6,11 +6,10 @@ import (
 	"sync/atomic"
 )
 
-
 //============================================= Mari
 
-
 // Open initializes Mari
+//
 //	This will create the memory mapped file or read it in if it already exists.
 //	Then, the meta data is initialized and written to the first 0-23 bytes in the memory map.
 //	An initial root MariINode will also be written to the memory map as well.
@@ -18,43 +17,51 @@ func Open(opts InitOpts) (*Mari, error) {
 	fileWithFilePath := filepath.Join(opts.Filepath, opts.FileName)
 
 	mariInst := &Mari{
-		filepath: opts.Filepath,
-		opened: true,
+		filepath:          opts.Filepath,
+		opened:            true,
 		signalCompactChan: make(chan bool),
-		signalFlushChan: make(chan bool),
-		signalResizeChan: make(chan bool),
+		signalFlushChan:   make(chan bool),
+		signalResizeChan:  make(chan bool),
 	}
 
 	if opts.NodePoolSize != nil {
 		nodePoolSize := *opts.NodePoolSize
 		mariInst.pool = newPool(nodePoolSize)
-	} else { mariInst.pool = newPool(DefaultNodePoolSize) }
+	} else {
+		mariInst.pool = newPool(DefaultNodePoolSize)
+	}
 
 	if opts.AppendOnly != nil {
 		mariInst.appendOnly = *opts.AppendOnly
-	} else { mariInst.appendOnly = false }
+	} else {
+		mariInst.appendOnly = false
+	}
 
-	if opts.CompactTrigger != nil {	
+	if opts.CompactTrigger != nil {
 		mariInst.compactTrigger = *opts.CompactTrigger
-	} else { 
+	} else {
 		mariInst.compactTrigger = func(metaData *MetaData) bool {
-			return metaData.version - 1 >= MaxCompactVersion
-		} 
+			return metaData.version-1 >= MaxCompactVersion
+		}
 	}
 
 	flag := os.O_RDWR | os.O_CREATE | os.O_APPEND
-	
+
 	var openErr error
 	mariInst.file, openErr = os.OpenFile(fileWithFilePath, flag, 0600)
-	if openErr != nil { return nil, openErr	}
+	if openErr != nil {
+		return nil, openErr
+	}
 
 	mariInst.filepath = opts.Filepath
-	
+
 	atomic.StoreUint32(&mariInst.isResizing, 0)
 	mariInst.data.Store(MMap{})
 
 	openErr = mariInst.initializeFile()
-	if openErr != nil { return nil, openErr	}
+	if openErr != nil {
+		return nil, openErr
+	}
 
 	go mariInst.compactHandler()
 	go mariInst.handleFlush()
@@ -64,51 +71,69 @@ func Open(opts InitOpts) (*Mari, error) {
 }
 
 // Close
+//
 //	Close Mari, unmapping the file from memory and closing the file.
 func (mariInst *Mari) Close() error {
 	var closeErr error
-	if ! mariInst.opened { return nil }
+	if !mariInst.opened {
+		return nil
+	}
 	mariInst.opened = false
 
 	closeErr = mariInst.file.Sync()
-	if closeErr != nil { return closeErr }
+	if closeErr != nil {
+		return closeErr
+	}
 
 	closeErr = mariInst.munmap()
-	if closeErr != nil { return closeErr }
+	if closeErr != nil {
+		return closeErr
+	}
 
 	if mariInst.file != nil {
 		closeErr = mariInst.file.Close()
-		if closeErr != nil { return closeErr }
+		if closeErr != nil {
+			return closeErr
+		}
 	}
 
 	return nil
 }
 
 // FileSize
+//
 //	Determine the memory mapped file size.
 func (mariInst *Mari) FileSize() (int, error) {
 	stat, statErr := mariInst.file.Stat()
-	if statErr != nil { return 0, statErr }
+	if statErr != nil {
+		return 0, statErr
+	}
 
 	size := int(stat.Size())
 	return size, nil
 }
 
 // Remove
+//
 //	Close Mari and remove the source file.
 func (mariInst *Mari) Remove() error {
 	var removeErr error
-	
+
 	removeErr = mariInst.Close()
-	if removeErr != nil { return removeErr }
+	if removeErr != nil {
+		return removeErr
+	}
 
 	removeErr = os.Remove(mariInst.file.Name())
-	if removeErr != nil { return removeErr }
+	if removeErr != nil {
+		return removeErr
+	}
 
 	return nil
 }
 
 // initializeFile
+//
 //	Initialize the memory mapped file to persist the hamt.
 //	If file size is 0, initiliaze the file size to 64MB and set the initial metadata and root values into the map.
 //	Otherwise, just map the already initialized file into the memory map.
@@ -116,19 +141,29 @@ func (mariInst *Mari) initializeFile() error {
 	var initErr error
 
 	fSize, initErr := mariInst.FileSize()
-	if initErr != nil { return initErr }
+	if initErr != nil {
+		return initErr
+	}
 
 	switch {
-		case fSize == 0:
-			_, initErr = mariInst.resizeMmap()
-			if initErr != nil { return initErr }
-			endOffset, initErr := mariInst.initRoot()
-			if initErr != nil { return initErr }
-			initErr = mariInst.initMeta(endOffset)
-			if initErr != nil { return initErr }
-		default:
-			initErr = mariInst.mmap()
-			if initErr != nil { return initErr }
+	case fSize == 0:
+		_, initErr = mariInst.resizeMmap()
+		if initErr != nil {
+			return initErr
+		}
+		endOffset, initErr := mariInst.initRoot()
+		if initErr != nil {
+			return initErr
+		}
+		initErr = mariInst.initMeta(endOffset)
+		if initErr != nil {
+			return initErr
+		}
+	default:
+		initErr = mariInst.mmap()
+		if initErr != nil {
+			return initErr
+		}
 	}
 
 	return nil

--- a/meta.go
+++ b/meta.go
@@ -6,32 +6,34 @@ import (
 	"unsafe"
 )
 
-
 //============================================= Mari Metadata
 
-
 // initMeta
+//
 //	Initialize and serialize the metadata in a new Mari.
 //	Version starts at 0 and increments, and root offset starts at 24.
 func (mariInst *Mari) initMeta(nextStart uint64) error {
 	newMeta := &MetaData{
-		version: 0,
-		rootOffset: uint64(InitRootOffset),
+		version:         0,
+		rootOffset:      uint64(InitRootOffset),
 		nextStartOffset: nextStart,
 	}
 
 	serializedMeta := newMeta.serializeMetaData()
 	_, flushErr := mariInst.writeMetaToMemMap(serializedMeta)
-	if flushErr != nil { return flushErr }
+	if flushErr != nil {
+		return flushErr
+	}
 	return nil
 }
 
 // loadMetaRootOffsetPointer
+//
 //	Get the uint64 pointer from the memory map.
 func (mariInst *Mari) loadMetaRootOffset() (ptr *uint64, rOff uint64, err error) {
 	defer func() {
 		r := recover()
-		if r != nil { 
+		if r != nil {
 			ptr = nil
 			rOff = 0
 			err = errors.New("error getting root offset from mmap")
@@ -45,11 +47,12 @@ func (mariInst *Mari) loadMetaRootOffset() (ptr *uint64, rOff uint64, err error)
 }
 
 // loadMetaEndMmapPointer
+//
 //	Get the uint64 pointer from the memory map.
 func (mariInst *Mari) loadMetaEndSerialized() (ptr *uint64, sOff uint64, err error) {
 	defer func() {
 		r := recover()
-		if r != nil { 
+		if r != nil {
 			ptr = nil
 			sOff = 0
 			err = errors.New("error getting end of serialized data from mmap")
@@ -63,11 +66,12 @@ func (mariInst *Mari) loadMetaEndSerialized() (ptr *uint64, sOff uint64, err err
 }
 
 // loadMetaVersionPointer
+//
 //	Get the uint64 pointer from the memory map.
 func (mariInst *Mari) loadMetaVersion() (ptr *uint64, v uint64, err error) {
 	defer func() {
 		r := recover()
-		if r != nil { 
+		if r != nil {
 			ptr = nil
 			v = 0
 			err = errors.New("error getting version from mmap")
@@ -81,11 +85,12 @@ func (mariInst *Mari) loadMetaVersion() (ptr *uint64, v uint64, err error) {
 }
 
 // storeMetaPointer
+//
 //	Store the pointer associated with the particular metadata (root offset, end serialized, version) back in the memory map.
 func (mariInst *Mari) storeMetaPointer(ptr *uint64, val uint64) (err error) {
 	defer func() {
 		r := recover()
-		if r != nil { 
+		if r != nil {
 			err = errors.New("error storing meta value in mmap")
 		}
 	}()
@@ -95,20 +100,23 @@ func (mariInst *Mari) storeMetaPointer(ptr *uint64, val uint64) (err error) {
 }
 
 // writeMetaToMemMap
+//
 //	Copy the serialized metadata into the memory map.
 func (mariInst *Mari) writeMetaToMemMap(sMeta []byte) (ok bool, err error) {
 	defer func() {
 		r := recover()
-		if r != nil { 
+		if r != nil {
 			ok = false
 			err = errors.New("error writing metadata to mmap")
 		}
 	}()
 
 	mMap := mariInst.data.Load().(MMap)
-	copy(mMap[MetaVersionIdx:MetaEndSerializedOffset + OffsetSize64], sMeta)
+	copy(mMap[MetaVersionIdx:MetaEndSerializedOffset+OffsetSize64], sMeta)
 
-	flushErr := mariInst.flushRegionToDisk(MetaVersionIdx, MetaEndSerializedOffset + OffsetSize64)
-	if flushErr != nil { return false, flushErr }
+	flushErr := mariInst.flushRegionToDisk(MetaVersionIdx, MetaEndSerializedOffset+OffsetSize64)
+	if flushErr != nil {
+		return false, flushErr
+	}
 	return true, nil
 }

--- a/mmap.go
+++ b/mmap.go
@@ -3,73 +3,87 @@ package mariv2
 import (
 	"errors"
 	"os"
+
 	"golang.org/x/sys/unix"
 )
 
-
 //============================================= MMap
 
-
-// Map 
+// Map
+//
 //	Memory maps an entire file.
 func Map(file *os.File, prot, flags int) (MMap, error) {
 	return mapRegion(file, -1, prot, flags, 0)
 }
 
 // Flush
+//
 //	Writes the byte slice from the mmap to disk.
 func (mapped MMap) Flush() error {
 	return unix.Msync(mapped, unix.MS_SYNC)
 }
 
-// Unmap 
+// Unmap
+//
 //	Unmaps the byte slice from the memory mapped file.
 func (mapped MMap) Unmap() error {
 	return unix.Munmap(mapped)
 }
 
-// mapRegion 
+// mapRegion
+//
 //	Memory maps a region of a file.
 func mapRegion(file *os.File, length int, prot, flags int, offset int64) (MMap, error) {
-	if offset % int64(os.Getpagesize()) != 0 { 
+	if offset%int64(os.Getpagesize()) != 0 {
 		return nil, errors.New("offset parameter must be a multiple of the system's page size")
 	}
 
 	var fileDescriptor uintptr
-	if flags & ANON == 0 {
+	if flags&ANON == 0 {
 		fileDescriptor = uintptr(file.Fd())
-		
+
 		if length < 0 {
 			fileStat, statErr := file.Stat()
-			if statErr != nil { return nil, statErr }
+			if statErr != nil {
+				return nil, statErr
+			}
 			length = int(fileStat.Size())
 		}
 	} else {
-		if length <= 0 { return nil, errors.New("anonymous mapping requires non-zero length") }
+		if length <= 0 {
+			return nil, errors.New("anonymous mapping requires non-zero length")
+		}
 		fileDescriptor = ^uintptr(0)
 	}
 
 	return mmapHelper(length, uintptr(prot), uintptr(flags), fileDescriptor, offset)
 }
 
-// mmapHelper 
+// mmapHelper
+//
 //	Utility function for mmap.
 func mmapHelper(length int, inprot, inflags, fileDescriptor uintptr, offset int64) ([]byte, error) {
 	flags := unix.MAP_SHARED
 	prot := unix.PROT_READ
-	
+
 	switch {
-		case inprot & COPY != 0:
-			prot |= unix.PROT_WRITE
-			flags = unix.MAP_PRIVATE
-		case inprot & RDWR != 0:
-			prot |= unix.PROT_WRITE
+	case inprot&COPY != 0:
+		prot |= unix.PROT_WRITE
+		flags = unix.MAP_PRIVATE
+	case inprot&RDWR != 0:
+		prot |= unix.PROT_WRITE
 	}
-	
-	if inprot & EXEC != 0 { prot |= unix.PROT_EXEC }
-	if inflags & ANON != 0 { flags |= unix.MAP_ANON }
+
+	if inprot&EXEC != 0 {
+		prot |= unix.PROT_EXEC
+	}
+	if inflags&ANON != 0 {
+		flags |= unix.MAP_ANON
+	}
 
 	bytes, mmapErr := unix.Mmap(int(fileDescriptor), offset, length, prot, flags)
-	if mmapErr != nil { return nil, mmapErr }
+	if mmapErr != nil {
+		return nil, mmapErr
+	}
 	return bytes, nil
 }

--- a/node.go
+++ b/node.go
@@ -6,18 +6,17 @@ import (
 	"unsafe"
 )
 
-
 //============================================= MariNode Operations
 
-
 // copyINode
+//
 //	Creates a copy of an existing internal node.
 //	This is used for path copying, so on operations that modify the trie, a copy is created instead of modifying the existing node.
-//	The data structure is essentially immutable. 
+//	The data structure is essentially immutable.
 //	If an operation succeeds, the copy replaces the existing node, otherwise the copy is discarded.
 func (mariInst *Mari) copyINode(node *INode) *INode {
 	nodeCopy := mariInst.pool.getINode()
-	
+
 	nodeCopy.version = node.version
 	nodeCopy.bitmap = node.bitmap
 	nodeCopy.leaf = node.leaf
@@ -28,35 +27,41 @@ func (mariInst *Mari) copyINode(node *INode) *INode {
 }
 
 // determineEndOffsetINode
+//
 //	Determine the end offset of a serialized MariINode.
 //	This will be the start offset through the children index, plus (number of children * 8 bytes).
 func (node *INode) determineEndOffsetINode() uint16 {
 	nodeEndOffset := uint16(0)
 	encodedChildrenLength := func() int {
-		var totalChildren int 
+		var totalChildren int
 		for _, subBitmap := range node.bitmap {
 			totalChildren += calculateHammingWeight(subBitmap)
 		}
-			
+
 		return totalChildren * NodeChildPtrSize
 	}()
 
 	if encodedChildrenLength != 0 {
 		nodeEndOffset += uint16(NodeChildrenIdx + encodedChildrenLength)
-	} else { nodeEndOffset += NodeChildrenIdx }
+	} else {
+		nodeEndOffset += NodeChildrenIdx
+	}
 
 	return nodeEndOffset - 1
 }
 
 // determineEndOffsetLNode
+//
 //	Determine the end offset of a serialized MariLNode.
 //	This will be the start offset through the key index, plus the length of the key and the length of the value.
 func (node *LNode) determineEndOffsetLNode() uint16 {
 	nodeEndOffset := uint16(0)
 	if node.key != nil {
 		nodeEndOffset += uint16(NodeKeyIdx + int(node.keyLength) + len(node.value))
-	} else { nodeEndOffset += NodeKeyIdx }
-	
+	} else {
+		nodeEndOffset += NodeKeyIdx
+	}
+
 	return nodeEndOffset - 1
 }
 
@@ -69,6 +74,7 @@ func (node *LNode) getEndOffsetLNode() uint64 {
 }
 
 // getChildNode
+//
 //	Get the child node of an internal node.
 //	If the version is the same, set child as that node since it exists in the path.
 //	Otherwise, read the node from the memory map.
@@ -80,36 +86,44 @@ func (mariInst *Mari) getChildNode(childOffset *INode, version uint64) (*INode, 
 		childNode = childOffset
 	} else {
 		childNode, desErr = mariInst.readINodeFromMemMap(childOffset.startOffset)
-		if desErr != nil { return nil, desErr }
+		if desErr != nil {
+			return nil, desErr
+		}
 	}
 
 	return childNode, nil
 }
 
 // getSerializedNodeSize
+//
 //	Get the length of the node based on the length of its serialized representation.
 func getSerializedNodeSize(data []byte) uint64 {
 	return uint64(len(data))
 }
 
 // initRoot
+//
 //	Initialize the version 0 root where operations will begin traversing.
 func (mariInst *Mari) initRoot() (uint64, error) {
 	root := mariInst.pool.getINode()
 	root.startOffset = uint64(InitRootOffset)
 
 	endOffset, writeNodeErr := mariInst.writeINodeToMemMap(root)
-	if writeNodeErr != nil { return 0, writeNodeErr }
+	if writeNodeErr != nil {
+		return 0, writeNodeErr
+	}
 	return endOffset, nil
 }
 
 // loadNodeFromPointer
+//
 //	Load Mari node from an unsafe pointer.
 func loadINodeFromPointer(ptr *unsafe.Pointer) *INode {
 	return (*INode)(atomic.LoadPointer(ptr))
 }
 
 // newInternalNode
+//
 //	Creates a new internal node in the ordered array mapped trie, which is essentially a branch node that contains pointers to child nodes.
 func (mariInst *Mari) newInternalNode(version uint64) *INode {
 	iNode := mariInst.pool.getINode()
@@ -118,6 +132,7 @@ func (mariInst *Mari) newInternalNode(version uint64) *INode {
 }
 
 // newLeafNode
+//
 //	Creates a new leaf node when path copying Mari, which stores a key value pair.
 //	It will also include the version of Mari.
 func (mariInst *Mari) newLeafNode(key, value []byte, version uint64) *LNode {
@@ -131,6 +146,7 @@ func (mariInst *Mari) newLeafNode(key, value []byte, version uint64) *LNode {
 }
 
 // readINodeFromMemMap
+//
 //	Reads an internal node in Mari from the serialized memory map.
 func (mariInst *Mari) readINodeFromMemMap(startOffset uint64) (node *INode, err error) {
 	defer func() {
@@ -140,28 +156,35 @@ func (mariInst *Mari) readINodeFromMemMap(startOffset uint64) (node *INode, err 
 			err = errors.New("error reading node from mem map")
 		}
 	}()
-	
-	var readErr error 
+
+	var readErr error
 	endOffsetIdx := startOffset + NodeEndOffsetIdx
-	
+
 	mMap := mariInst.data.Load().(MMap)
-	sEndOffset := mMap[endOffsetIdx:endOffsetIdx + OffsetSize16]
+	sEndOffset := mMap[endOffsetIdx : endOffsetIdx+OffsetSize16]
 
 	endOffset, readErr := deserializeUint16(sEndOffset)
-	if readErr != nil { return nil, readErr }
+	if readErr != nil {
+		return nil, readErr
+	}
 
-	sNode := mMap[startOffset:startOffset + uint64(endOffset) + 1]
+	sNode := mMap[startOffset : startOffset+uint64(endOffset)+1]
 	node, readErr = deserializeINode(sNode)
-	if readErr != nil { return nil, readErr }
+	if readErr != nil {
+		return nil, readErr
+	}
 
 	leaf, readErr := mariInst.readLNodeFromMemMap(node.leaf.startOffset)
-	if readErr != nil { return nil, readErr }
+	if readErr != nil {
+		return nil, readErr
+	}
 
 	node.leaf = leaf
 	return node, nil
 }
 
 // readLNodeFromMemMap
+//
 //	Reads a leaf node in Mari from the serialized memory map.
 func (mariInst *Mari) readLNodeFromMemMap(startOffset uint64) (node *LNode, err error) {
 	defer func() {
@@ -171,22 +194,27 @@ func (mariInst *Mari) readLNodeFromMemMap(startOffset uint64) (node *LNode, err 
 			err = errors.New("error reading node from mem map")
 		}
 	}()
-	
-	var readErr error 
+
+	var readErr error
 	endOffsetIdx := startOffset + NodeEndOffsetIdx
 	mMap := mariInst.data.Load().(MMap)
-	sEndOffset := mMap[endOffsetIdx:endOffsetIdx + OffsetSize16]
+	sEndOffset := mMap[endOffsetIdx : endOffsetIdx+OffsetSize16]
 
 	endOffset, readErr := deserializeUint16(sEndOffset)
-	if readErr != nil { return nil, readErr }
+	if readErr != nil {
+		return nil, readErr
+	}
 
-	sNode := mMap[startOffset:startOffset + uint64(endOffset) + 1]
+	sNode := mMap[startOffset : startOffset+uint64(endOffset)+1]
 	node, readErr = deserializeLNode(sNode)
-	if readErr != nil { return nil, readErr }
+	if readErr != nil {
+		return nil, readErr
+	}
 	return node, nil
 }
 
 // storeNodeAsPointer
+//
 //	Store a MariINode as an unsafe pointer.
 func storeINodeAsPointer(node *INode) *unsafe.Pointer {
 	ptr := unsafe.Pointer(node)
@@ -194,6 +222,7 @@ func storeINodeAsPointer(node *INode) *unsafe.Pointer {
 }
 
 // writeINodeToMemMap
+//
 //	Serializes and writes an internal node instance to the memory map.
 func (mariInst *Mari) writeINodeToMemMap(node *INode) (offset uint64, err error) {
 	defer func() {
@@ -206,20 +235,27 @@ func (mariInst *Mari) writeINodeToMemMap(node *INode) (offset uint64, err error)
 
 	var writeErr error
 	sNode, writeErr := node.serializeINode(false)
-	if writeErr != nil { return 0, writeErr	}
+	if writeErr != nil {
+		return 0, writeErr
+	}
 
 	mMap := mariInst.data.Load().(MMap)
-	copy(mMap[node.startOffset:node.leaf.startOffset + 1], sNode)
+	copy(mMap[node.startOffset:node.leaf.startOffset+1], sNode)
 
 	writeErr = mariInst.flushRegionToDisk(node.startOffset, node.getEndOffsetINode())
-	if writeErr != nil { return 0, writeErr } 
+	if writeErr != nil {
+		return 0, writeErr
+	}
 
 	lEndOffset, writeErr := mariInst.writeLNodeToMemMap(node.leaf)
-	if writeErr != nil { return 0, writeErr }
+	if writeErr != nil {
+		return 0, writeErr
+	}
 	return lEndOffset, nil
 }
 
 // writeLNodeToMemMap
+//
 //	Serializes and writes a MariNode instance to the memory map.
 func (mariInst *Mari) writeLNodeToMemMap(node *LNode) (offset uint64, err error) {
 	defer func() {
@@ -232,18 +268,23 @@ func (mariInst *Mari) writeLNodeToMemMap(node *LNode) (offset uint64, err error)
 
 	var writeErr error
 	sNode, writeErr := node.serializeLNode()
-	if writeErr != nil { return 0, writeErr	}
+	if writeErr != nil {
+		return 0, writeErr
+	}
 
 	endOffset := node.getEndOffsetLNode()
 	mMap := mariInst.data.Load().(MMap)
-	copy(mMap[node.startOffset:endOffset + 1], sNode)
+	copy(mMap[node.startOffset:endOffset+1], sNode)
 
 	writeErr = mariInst.flushRegionToDisk(node.startOffset, endOffset)
-	if writeErr != nil { return 0, writeErr } 
+	if writeErr != nil {
+		return 0, writeErr
+	}
 	return endOffset + 1, nil
 }
 
 // writeNodesToMemMap
+//
 //	Write a list of serialized nodes to the memory map. If the mem map is too small for the incoming nodes, dynamically resize.
 func (mariInst *Mari) writeNodesToMemMap(snodes []byte, offset uint64) (ok bool, err error) {
 	defer func() {

--- a/pool.go
+++ b/pool.go
@@ -5,23 +5,22 @@ import (
 	"sync/atomic"
 )
 
-
 //============================================= Mari Node Pool
 
-
 // NewMariNodePool
+//
 //	Creates a new node pool for recycling nodes instead of letting garbage collection handle them.
 //	Should help performance when there are a large number of go routines attempting to allocate/deallocate nodes.
 func newPool(maxSize int64) *Pool {
 	size := int64(0)
-	np := &Pool{ maxSize: maxSize, size: size }
+	np := &Pool{maxSize: maxSize, size: size}
 
-	iPool := &sync.Pool { 
-		New: func() interface {} { return np.resetINode(&INode{}) },
+	iPool := &sync.Pool{
+		New: func() interface{} { return np.resetINode(&INode{}) },
 	}
 
-	lPool := &sync.Pool {
-		New: func() interface {} { return np.resetLNode(&LNode{}) },
+	lPool := &sync.Pool{
+		New: func() interface{} { return np.resetLNode(&LNode{}) },
 	}
 
 	np.iPool = iPool
@@ -31,60 +30,70 @@ func newPool(maxSize int64) *Pool {
 }
 
 // getINode
+//
 //	Attempt to get a pre-allocated internal node from the node pool and decrement the total allocated nodes.
 //	If the pool is empty, a new node is allocated
 func (p *Pool) getINode() *INode {
 	node := p.iPool.Get().(*INode)
-	if atomic.LoadInt64(&p.size) > 0 { atomic.AddInt64(&p.size, -1) }
+	if atomic.LoadInt64(&p.size) > 0 {
+		atomic.AddInt64(&p.size, -1)
+	}
 
 	return node
 }
 
 // getLNode
+//
 //	Attempt to get a pre-allocated leaf node from the node pool and decrement the total allocated nodes.
 //	If the pool is empty, a new node is allocated
 func (p *Pool) getLNode() *LNode {
 	node := p.lPool.Get().(*LNode)
-	if atomic.LoadInt64(&p.size) > 0 { atomic.AddInt64(&p.size, -1) }
+	if atomic.LoadInt64(&p.size) > 0 {
+		atomic.AddInt64(&p.size, -1)
+	}
 
 	return node
 }
 
 // initializePool
+//
 //	When Mari is opened, initialize the pool with the max size of nodes.
 func (p *Pool) initializePools() {
-	for range make([]int, p.maxSize / 2) {
+	for range make([]int, p.maxSize/2) {
 		p.iPool.Put(p.resetINode(&INode{}))
 		atomic.AddInt64(&p.size, 1)
 	}
 
-	for range make([]int, p.maxSize / 2) {
+	for range make([]int, p.maxSize/2) {
 		p.lPool.Put(p.resetLNode(&LNode{}))
 		atomic.AddInt64(&p.size, 1)
 	}
 }
 
 // putINode
+//
 //	Attempt to put an internal node back into the pool once a path has been copied + serialized.
 //	If the pool is at max capacity, drop the node and let the garbage collector take care of it.
 func (p *Pool) putINode(node *INode) {
-	if atomic.LoadInt64(&p.size) < p.maxSize { 
+	if atomic.LoadInt64(&p.size) < p.maxSize {
 		p.iPool.Put(p.resetINode(node))
 		atomic.AddInt64(&p.size, 1)
 	}
 }
 
 // putLNode
+//
 //	Attempt to put a leaf node back into the pool once a path has been copied + serialized.
 //	If the pool is at max capacity, drop the node and let the garbage collector take care of it.
 func (p *Pool) putLNode(node *LNode) {
-	if atomic.LoadInt64(&p.size) < p.maxSize { 
+	if atomic.LoadInt64(&p.size) < p.maxSize {
 		p.lPool.Put(p.resetLNode(node))
 		atomic.AddInt64(&p.size, 1)
 	}
 }
 
 // resetINode
+//
 //	When an internal node is put back in the pool, reset the values.
 func (p *Pool) resetINode(node *INode) *INode {
 	node.version = 0
@@ -92,18 +101,19 @@ func (p *Pool) resetINode(node *INode) *INode {
 	node.endOffset = 0
 	node.bitmap = [8]uint32{0, 0, 0, 0, 0, 0, 0, 0}
 	node.children = make([]*INode, 0)
-	node.leaf = &LNode{ 
-		version: 0, 
-		startOffset: 0, 
-		endOffset: 0,
-		keyLength: 0, 
-		key: nil, 
-		value: nil, 
+	node.leaf = &LNode{
+		version:     0,
+		startOffset: 0,
+		endOffset:   0,
+		keyLength:   0,
+		key:         nil,
+		value:       nil,
 	}
 	return node
 }
 
 // resetLNode
+//
 //	When a leaf node is put back in the pool, reset the values.
 func (p *Pool) resetLNode(node *LNode) *LNode {
 	node.version = 0

--- a/range.go
+++ b/range.go
@@ -5,53 +5,58 @@ import (
 	"unsafe"
 )
 
-
 //============================================= Mari Range
 
-
 // rangeRecursive
+//
 //	Limit the indexes to check in the range at level 0, and then recursively traverse the paths between the start and end index.
 //	On the start key path, continue to use the start index to check the level to see which index forward should be recursively checked.
 //	The opposite is done for the end key path.
 func (mariInst *Mari) rangeRecursive(node *unsafe.Pointer, minVersion uint64, startKey, endKey []byte, level int, transform Transform) ([]*KeyValuePair, error) {
-	genKeyValPair := func(node *INode) *KeyValuePair { return &KeyValuePair { Key: node.leaf.key, Value: node.leaf.value } }
+	genKeyValPair := func(node *INode) *KeyValuePair { return &KeyValuePair{Key: node.leaf.key, Value: node.leaf.value} }
 	currNode := loadINodeFromPointer(node)
 
 	var sortedKvPairs []*KeyValuePair
 	var startKeyPos, endKeyPos int
 	if level > 0 {
 		switch {
-			case startKey != nil && len(startKey) > level:
-				if currNode.leaf.version >= minVersion && bytes.Compare(currNode.leaf.key, startKey) == 1 {
-					sortedKvPairs = append(sortedKvPairs, transform(genKeyValPair(currNode)))
-				} else { return sortedKvPairs, nil }
+		case startKey != nil && len(startKey) > level:
+			if currNode.leaf.version >= minVersion && bytes.Compare(currNode.leaf.key, startKey) == 1 {
+				sortedKvPairs = append(sortedKvPairs, transform(genKeyValPair(currNode)))
+			} else {
+				return sortedKvPairs, nil
+			}
 
-				startKeyIndex := getIndexForLevel(startKey, level)
-				startKeyPos = getPosition(currNode.bitmap, startKeyIndex, level)
-				endKeyPos = len(currNode.children)
-			case endKey != nil && len(endKey) > level:
-				if currNode.leaf.version >= minVersion && bytes.Compare(currNode.leaf.key, endKey) == -1 {
-					sortedKvPairs = append(sortedKvPairs, transform(genKeyValPair(currNode)))
-				} else { return sortedKvPairs, nil }
+			startKeyIndex := getIndexForLevel(startKey, level)
+			startKeyPos = getPosition(currNode.bitmap, startKeyIndex, level)
+			endKeyPos = len(currNode.children)
+		case endKey != nil && len(endKey) > level:
+			if currNode.leaf.version >= minVersion && bytes.Compare(currNode.leaf.key, endKey) == -1 {
+				sortedKvPairs = append(sortedKvPairs, transform(genKeyValPair(currNode)))
+			} else {
+				return sortedKvPairs, nil
+			}
 
-				startKeyPos = 0
-				endKeyIndex := getIndexForLevel(endKey, level)
-				endKeyPos = getPosition(currNode.bitmap, endKeyIndex, level)
-			default:
-				if currNode.leaf.version >= minVersion && len(currNode.leaf.key) > 0 { sortedKvPairs = append(sortedKvPairs, transform(genKeyValPair(currNode))) }
-				startKeyPos = 0
-				endKeyPos = len(currNode.children)
+			startKeyPos = 0
+			endKeyIndex := getIndexForLevel(endKey, level)
+			endKeyPos = getPosition(currNode.bitmap, endKeyIndex, level)
+		default:
+			if currNode.leaf.version >= minVersion && len(currNode.leaf.key) > 0 {
+				sortedKvPairs = append(sortedKvPairs, transform(genKeyValPair(currNode)))
+			}
+			startKeyPos = 0
+			endKeyPos = len(currNode.children)
 		}
 	} else {
 		switch {
-			case startKey == nil && endKey == nil:
-				startKeyPos = 0
-				endKeyPos = len(currNode.children)
-			default:
-				startKeyIndex := getIndexForLevel(startKey, 0)
-				startKeyPos = getPosition(currNode.bitmap, startKeyIndex, 0)
-				endKeyIndex := getIndexForLevel(endKey, 0)
-				endKeyPos = getPosition(currNode.bitmap, endKeyIndex, 0)
+		case startKey == nil && endKey == nil:
+			startKeyPos = 0
+			endKeyPos = len(currNode.children)
+		default:
+			startKeyIndex := getIndexForLevel(startKey, 0)
+			startKeyPos = getPosition(currNode.bitmap, startKeyIndex, 0)
+			endKeyIndex := getIndexForLevel(endKey, 0)
+			endKeyPos = getPosition(currNode.bitmap, endKeyIndex, 0)
 		}
 	}
 
@@ -62,34 +67,50 @@ func (mariInst *Mari) rangeRecursive(node *unsafe.Pointer, minVersion uint64, st
 		var kvPairs []*KeyValuePair
 
 		switch {
-			case startKeyPos == endKeyPos:
-				childNode, rangeErr = mariInst.getChildNode(currNode.children[startKeyPos], currNode.version)
-				if rangeErr != nil { return nil, rangeErr}
-				childPtr = storeINodeAsPointer(childNode)
+		case startKeyPos == endKeyPos:
+			childNode, rangeErr = mariInst.getChildNode(currNode.children[startKeyPos], currNode.version)
+			if rangeErr != nil {
+				return nil, rangeErr
+			}
+			childPtr = storeINodeAsPointer(childNode)
 
-				kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, startKey, endKey, level + 1, transform)
-				if rangeErr != nil { return nil, rangeErr }
-				if len(kvPairs) > 0 { sortedKvPairs = append(sortedKvPairs, kvPairs...) }
-			default:
-				for idx, childOffset := range currNode.children[startKeyPos:endKeyPos] {		
-					childNode, rangeErr = mariInst.getChildNode(childOffset, currNode.version)
-					if rangeErr != nil { return nil, rangeErr }
-					
-					childPtr = storeINodeAsPointer(childNode)
-					switch {
-						case idx == 0 && startKey != nil:
-							kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, startKey, nil, level + 1, transform)
-							if rangeErr != nil { return nil, rangeErr }
-						case idx == endKeyPos && endKey != nil:
-							kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, nil, endKey, level + 1, transform)
-							if rangeErr != nil { return nil, rangeErr }
-						default:
-							kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, nil, nil, level + 1, transform)
-							if rangeErr != nil { return nil, rangeErr }
-					}
-		
-					if len(kvPairs) > 0 { sortedKvPairs = append(sortedKvPairs, kvPairs...) }
+			kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, startKey, endKey, level+1, transform)
+			if rangeErr != nil {
+				return nil, rangeErr
+			}
+			if len(kvPairs) > 0 {
+				sortedKvPairs = append(sortedKvPairs, kvPairs...)
+			}
+		default:
+			for idx, childOffset := range currNode.children[startKeyPos:endKeyPos] {
+				childNode, rangeErr = mariInst.getChildNode(childOffset, currNode.version)
+				if rangeErr != nil {
+					return nil, rangeErr
 				}
+
+				childPtr = storeINodeAsPointer(childNode)
+				switch {
+				case idx == 0 && startKey != nil:
+					kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, startKey, nil, level+1, transform)
+					if rangeErr != nil {
+						return nil, rangeErr
+					}
+				case idx == endKeyPos && endKey != nil:
+					kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, nil, endKey, level+1, transform)
+					if rangeErr != nil {
+						return nil, rangeErr
+					}
+				default:
+					kvPairs, rangeErr = mariInst.rangeRecursive(childPtr, minVersion, nil, nil, level+1, transform)
+					if rangeErr != nil {
+						return nil, rangeErr
+					}
+				}
+
+				if len(kvPairs) > 0 {
+					sortedKvPairs = append(sortedKvPairs, kvPairs...)
+				}
+			}
 		}
 	}
 

--- a/tests/mari_test.go
+++ b/tests/mari_test.go
@@ -2,8 +2,8 @@ package maritests
 
 import (
 	"fmt"
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirgallo/mariv2"
@@ -11,20 +11,20 @@ import (
 
 var mariInst *mariv2.Mari
 
-
 func init() {
 	os.Remove(filepath.Join(os.TempDir(), "testmari"))
 	os.Remove(filepath.Join(os.TempDir(), "testmaritemp"))
 
 	var initPCMapErr error
-	
-	opts := mariv2.InitOpts{ Filepath: os.TempDir(), FileName: "testmari" }
+
+	opts := mariv2.InitOpts{Filepath: os.TempDir(), FileName: "testmari"}
 	mariInst, initPCMapErr = mariv2.Open(opts)
-	if initPCMapErr != nil { panic(initPCMapErr.Error()) }
+	if initPCMapErr != nil {
+		panic(initPCMapErr.Error())
+	}
 
 	fmt.Println("op test mari initialized")
 }
-
 
 func TestMari(t *testing.T) {
 	defer mariInst.Remove()
@@ -35,63 +35,101 @@ func TestMari(t *testing.T) {
 	t.Run("Test Mari Put", func(t *testing.T) {
 		putErr = mariInst.UpdateTx(func(tx *mariv2.Tx) error {
 			putErr = tx.Put([]byte("hello"), []byte("world"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("new"), []byte("wow!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("again"), []byte("test!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("woah"), []byte("random entry"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("key"), []byte("Saturday!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("sup"), []byte("6"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("final"), []byte("the!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("asdfasdf"), []byte("add 10"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("asdfasdf"), []byte("123123"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("asd"), []byte("queue!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("fasdf"), []byte("interesting"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("yup"), []byte("random again!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("asdf"), []byte("hello"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("asdffasd"), []byte("uh oh!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("fasdfasdfasdfasdf"), []byte("error message"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("fasdfasdf"), []byte("info!"))
-			if putErr != nil { return putErr }
-	
+			if putErr != nil {
+				return putErr
+			}
+
 			putErr = tx.Put([]byte("woah"), []byte("done"))
-			if putErr != nil { return putErr }
+			if putErr != nil {
+				return putErr
+			}
 
 			putErr = tx.Put([]byte("Woah"), []byte("done"))
-			if putErr != nil { return putErr }
-			
+			if putErr != nil {
+				return putErr
+			}
+
 			return nil
 		})
 
-		if putErr != nil { t.Errorf("error on udpate tx: %s\n", putErr.Error())}
+		if putErr != nil {
+			t.Errorf("error on udpate tx: %s\n", putErr.Error())
+		}
 
 		t.Logf("mariInst after inserts")
 		mariInst.PrintChildren()
@@ -101,48 +139,80 @@ func TestMari(t *testing.T) {
 		getErr := mariInst.ReadTx(func(tx *mariv2.Tx) error {
 			expVal1 := "world"
 			val1, getErr = tx.Get([]byte("hello"), nil)
-			if getErr != nil { return getErr }
-			if val1 == nil { t.Error("val actually nil") }
-	
+			if getErr != nil {
+				return getErr
+			}
+			if val1 == nil {
+				t.Error("val actually nil")
+			}
+
 			t.Logf("actual: %s, expected: %s", string(val1.Value), expVal1)
-			if string(val1.Value) != expVal1 { t.Errorf("val 1 does not match expected val 1: actual(%s), expected(%s)\n", val1.Value, expVal1) }
-	
+			if string(val1.Value) != expVal1 {
+				t.Errorf("val 1 does not match expected val 1: actual(%s), expected(%s)\n", val1.Value, expVal1)
+			}
+
 			expVal2 := "wow!"
 			val2, getErr = tx.Get([]byte("new"), nil)
-			if getErr != nil { return getErr }
-			if val2 == nil { t.Error("val actually nil") }
-	
+			if getErr != nil {
+				return getErr
+			}
+			if val2 == nil {
+				t.Error("val actually nil")
+			}
+
 			t.Logf("actual: %s, expected: %s", val2.Value, expVal2)
-			if string(val2.Value) != expVal2 { t.Errorf("val 2 does not match expected val 2: actual(%s), expected(%s)\n", val2.Value, expVal2) }
-	
+			if string(val2.Value) != expVal2 {
+				t.Errorf("val 2 does not match expected val 2: actual(%s), expected(%s)\n", val2.Value, expVal2)
+			}
+
 			expVal3 := "hello"
 			val3, getErr = tx.Get([]byte("asdf"), nil)
-			if getErr != nil { return getErr }
-			if val3 == nil { t.Error("val actually nil") }
-			
+			if getErr != nil {
+				return getErr
+			}
+			if val3 == nil {
+				t.Error("val actually nil")
+			}
+
 			t.Logf("actual: %s, expected: %s", val3.Value, expVal3)
-			if string(val3.Value) != expVal3 { t.Errorf("val 3 does not match expected val 3: actual(%s), expected(%s)", val3.Value, expVal3) }
-	
+			if string(val3.Value) != expVal3 {
+				t.Errorf("val 3 does not match expected val 3: actual(%s), expected(%s)", val3.Value, expVal3)
+			}
+
 			expVal4 := "123123"
 			val4, getErr = tx.Get([]byte("asdfasdf"), nil)
-			if getErr != nil { return getErr }
-			if val4 == nil { t.Error("val actually nil") }
-	
+			if getErr != nil {
+				return getErr
+			}
+			if val4 == nil {
+				t.Error("val actually nil")
+			}
+
 			t.Logf("actual: %s, expected: %s", val4.Value, expVal4)
-			if string(val4.Value) != expVal4 { t.Errorf("val 4 does not match expected val 4: actual(%s), expected(%s)", val4.Value, expVal4) }
+			if string(val4.Value) != expVal4 {
+				t.Errorf("val 4 does not match expected val 4: actual(%s), expected(%s)", val4.Value, expVal4)
+			}
 
 			expVal5 := "done"
 			val5, getErr = tx.Get([]byte("Woah"), nil)
-			if getErr != nil { return getErr }
-			if val5 == nil { t.Error("val actually nil") }
-	
+			if getErr != nil {
+				return getErr
+			}
+			if val5 == nil {
+				t.Error("val actually nil")
+			}
+
 			t.Logf("actual: %s, expected: %s", val5.Value, expVal5)
-			if string(val5.Value) != expVal5 { t.Errorf("val 4 does not match expected val 4: actual(%s), expected(%s)", val5.Value, expVal5) }
-			
+			if string(val5.Value) != expVal5 {
+				t.Errorf("val 4 does not match expected val 4: actual(%s), expected(%s)", val5.Value, expVal5)
+			}
+
 			return nil
 		})
 
-		if getErr != nil { t.Errorf("error getting val: %s", getErr.Error()) }
+		if getErr != nil {
+			t.Errorf("error getting val: %s", getErr.Error())
+		}
 	})
 
 	t.Run("Test Iterate Operation", func(t *testing.T) {
@@ -151,16 +221,20 @@ func TestMari(t *testing.T) {
 		iterErr := mariInst.ReadTx(func(tx *mariv2.Tx) error {
 			var txIterErr error
 			kvPairs, txIterErr = tx.Iterate([]byte("hello"), 3, nil)
-			if txIterErr != nil { return txIterErr }
+			if txIterErr != nil {
+				return txIterErr
+			}
 
 			return nil
 		})
 
-		if iterErr != nil { t.Errorf("error on mari range: %s", iterErr.Error()) }
+		if iterErr != nil {
+			t.Errorf("error on mari range: %s", iterErr.Error())
+		}
 
-		t.Log("keys in kv pairs", func() []string{
+		t.Log("keys in kv pairs", func() []string {
 			var keys []string
-			for _, kv := range kvPairs { 
+			for _, kv := range kvPairs {
 				keys = append(keys, string(kv.Key))
 			}
 
@@ -170,7 +244,7 @@ func TestMari(t *testing.T) {
 		isSorted := IsSorted(kvPairs)
 		t.Logf("is sorted: %t", isSorted)
 
-		if ! isSorted {
+		if !isSorted {
 			t.Errorf("key value pairs are not in sorted order: %t", isSorted)
 		}
 	})
@@ -181,15 +255,19 @@ func TestMari(t *testing.T) {
 		rangeErr := mariInst.ReadTx(func(tx *mariv2.Tx) error {
 			var txRangeErr error
 			kvPairs, txRangeErr = tx.Range([]byte("hello"), []byte("yup"), nil)
-			if txRangeErr != nil { return txRangeErr }
+			if txRangeErr != nil {
+				return txRangeErr
+			}
 			return nil
 		})
 
-		if rangeErr != nil { t.Errorf("error on mari range: %s", rangeErr.Error()) }
+		if rangeErr != nil {
+			t.Errorf("error on mari range: %s", rangeErr.Error())
+		}
 
-		t.Log("keys in kv pairs", func() []string{
+		t.Log("keys in kv pairs", func() []string {
 			var keys []string
-			for _, kv := range kvPairs { 
+			for _, kv := range kvPairs {
 				keys = append(keys, string(kv.Key))
 			}
 
@@ -199,7 +277,7 @@ func TestMari(t *testing.T) {
 		isSorted := IsSorted(kvPairs)
 		t.Logf("is sorted: %t", isSorted)
 
-		if ! isSorted {
+		if !isSorted {
 			t.Errorf("key value pairs are not in sorted order: %t", isSorted)
 		}
 	})
@@ -212,26 +290,30 @@ func TestMari(t *testing.T) {
 			return kvPair
 		}
 
-		opts := &mariv2.RangeOpts{ Transform: &transform }
+		opts := &mariv2.RangeOpts{Transform: &transform}
 		iterErr := mariInst.ReadTx(func(tx *mariv2.Tx) error {
 			var txIterErr error
 			kvPairs, txIterErr = tx.Iterate([]byte("hello"), 3, opts)
-			if txIterErr != nil { return txIterErr }
+			if txIterErr != nil {
+				return txIterErr
+			}
 			return nil
 		})
 
-		if iterErr != nil { t.Errorf("error on mari range: %s", iterErr.Error()) }
+		if iterErr != nil {
+			t.Errorf("error on mari range: %s", iterErr.Error())
+		}
 
-		t.Log("keys in kv pairs:", func() []string{
+		t.Log("keys in kv pairs:", func() []string {
 			var keys []string
-			for _, kv := range kvPairs { 
+			for _, kv := range kvPairs {
 				keys = append(keys, string(kv.Key))
 			}
 
 			return keys
-		}(), "transformed values in kv pairs:", func() []string{
+		}(), "transformed values in kv pairs:", func() []string {
 			var values []string
-			for _, kv := range kvPairs { 
+			for _, kv := range kvPairs {
 				values = append(values, string(kv.Value))
 			}
 
@@ -241,7 +323,7 @@ func TestMari(t *testing.T) {
 		isSorted := IsSorted(kvPairs)
 		t.Logf("is sorted: %t", isSorted)
 
-		if ! isSorted {
+		if !isSorted {
 			t.Errorf("key value pairs are not in sorted order: %t", isSorted)
 		}
 	})
@@ -249,24 +331,36 @@ func TestMari(t *testing.T) {
 	t.Run("Test Mari Delete", func(t *testing.T) {
 		delErr = mariInst.UpdateTx(func(tx *mariv2.Tx) error {
 			delTxErr := tx.Delete([]byte("hello"))
-			if delTxErr != nil { return delTxErr }
-	
+			if delTxErr != nil {
+				return delTxErr
+			}
+
 			delTxErr = tx.Delete([]byte("yup"))
-			if delTxErr != nil { return delTxErr }
-	
+			if delTxErr != nil {
+				return delTxErr
+			}
+
 			delTxErr = tx.Delete([]byte("asdf"))
-			if delTxErr != nil { return delTxErr }
-	
+			if delTxErr != nil {
+				return delTxErr
+			}
+
 			delTxErr = tx.Delete([]byte("asdfasdf"))
-			if delTxErr != nil { return delTxErr }
-	
+			if delTxErr != nil {
+				return delTxErr
+			}
+
 			delTxErr = tx.Delete([]byte("new"))
-			if delTxErr != nil { return delTxErr }
-			
+			if delTxErr != nil {
+				return delTxErr
+			}
+
 			return nil
 		})
 
-		if delErr != nil { t.Errorf("error deleting key from mari: %s", delErr.Error()) }
+		if delErr != nil {
+			t.Errorf("error deleting key from mari: %s", delErr.Error())
+		}
 
 		t.Log("mari after deletes")
 		mariInst.PrintChildren()

--- a/tests/mmap_test.go
+++ b/tests/mmap_test.go
@@ -3,17 +3,15 @@ package maritests
 import (
 	"bytes"
 	"io"
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/sirgallo/mariv2"
 )
 
-
 var TestMMapData = []byte("0123456789ABCDEF")
 var TestMMapPath = filepath.Join(os.TempDir(), "testfile")
-
 
 func init() {
 	testFile := openFile(os.O_RDWR | os.O_CREATE | os.O_TRUNC)
@@ -23,42 +21,55 @@ func init() {
 
 func openFile(flags int) *os.File {
 	file, openErr := os.OpenFile(TestMMapPath, flags, 0644)
-	if openErr != nil { panic(openErr.Error()) }
+	if openErr != nil {
+		panic(openErr.Error())
+	}
 
 	return file
 }
-
 
 func TestMMap(t *testing.T) {
 	t.Run("Test Unmap", func(t *testing.T) {
 		testFile := openFile(os.O_RDONLY)
 		defer testFile.Close()
-	
+
 		mMap, mmapErr := mariv2.Map(testFile, mariv2.RDONLY, 0)
-		if mmapErr != nil { t.Errorf("error mapping: %s", mmapErr) }
-	
-		unmapErr := mMap.Unmap() 
-		if unmapErr != nil { t.Errorf("mmap != testData: %q, %q", mMap, TestMMapData) }
+		if mmapErr != nil {
+			t.Errorf("error mapping: %s", mmapErr)
+		}
+
+		unmapErr := mMap.Unmap()
+		if unmapErr != nil {
+			t.Errorf("mmap != testData: %q, %q", mMap, TestMMapData)
+		}
 	})
 
 	t.Run("Test Read Write", func(t *testing.T) {
 		testFile := openFile(os.O_RDWR)
 		defer testFile.Close()
-		
+
 		mMap, mmapErr := mariv2.Map(testFile, mariv2.RDWR, 0)
-		if mmapErr != nil { t.Errorf("error mapping: %s", mmapErr) }
-	
+		if mmapErr != nil {
+			t.Errorf("error mapping: %s", mmapErr)
+		}
+
 		defer mMap.Unmap()
-		
-		if ! bytes.Equal(TestMMapData, mMap) { t.Errorf("mmap != testData: %q, %q", mMap, TestMMapData) }
-	
+
+		if !bytes.Equal(TestMMapData, mMap) {
+			t.Errorf("mmap != testData: %q, %q", mMap, TestMMapData)
+		}
+
 		mMap[9] = 'X'
 		mMap.Flush()
-	
+
 		fileData, err := io.ReadAll(testFile)
-		if err != nil { t.Errorf("error reading file: %s", err) }
-		if ! bytes.Equal(fileData, []byte("012345678XABCDEF")) { t.Errorf("file wasn't modified") }
-	
+		if err != nil {
+			t.Errorf("error reading file: %s", err)
+		}
+		if !bytes.Equal(fileData, []byte("012345678XABCDEF")) {
+			t.Errorf("file wasn't modified")
+		}
+
 		mMap[9] = '9'
 		mMap.Flush()
 	})

--- a/tests/shared.go
+++ b/tests/shared.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sirgallo/mariv2"
 )
 
-
 const NUM_WRITER_GO_ROUTINES = 2
 const NUM_READER_GO_ROUTINES = 10
 const NUM_RANGE_GO_ROUTINES = 10
@@ -22,24 +21,26 @@ const READ_CHUNK_SIZE = INPUT_SIZE / NUM_READER_GO_ROUTINES
 const PCHUNK_SIZE_READ = (INPUT_SIZE - PWRITE_INPUT_SIZE) / NUM_READER_GO_ROUTINES
 const PCHUNK_SIZE_WRITE = PWRITE_INPUT_SIZE / NUM_WRITER_GO_ROUTINES
 
-
 type KeyVal struct {
-	Key []byte
+	Key   []byte
 	Value []byte
 }
 
-
 func GenerateRandomBytes(length int) ([]byte, error) {
- 	byteMapping := func(b byte) byte {
+	byteMapping := func(b byte) byte {
 		const charset = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		return charset[b%62]
 	}
 
-	if length <= 0 { return nil, errors.New("length must be greater than 0") }
+	if length <= 0 {
+		return nil, errors.New("length must be greater than 0")
+	}
 
 	randomBytes := make([]byte, length)
 	_, err := rand.Read(randomBytes)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	for i := 0; i < length; i++ {
 		randomBytes[i] = byteMapping(randomBytes[i])
@@ -49,13 +50,17 @@ func GenerateRandomBytes(length int) ([]byte, error) {
 }
 
 func TwoRandomDistinctValues(min, max int) (int, int, error) {
-	if min >= max { return 0, 0, errors.New("min cannot be greater than max") }
+	if min >= max {
+		return 0, 0, errors.New("min cannot be greater than max")
+	}
 
-	first := mrand.Intn(max - min) + min
+	first := mrand.Intn(max-min) + min
 	var second int
 	for {
-		second = mrand.Intn(max - min) + min
-		if second != first { break }
+		second = mrand.Intn(max-min) + min
+		if second != first {
+			break
+		}
 	}
 
 	return first, second, nil
@@ -63,31 +68,37 @@ func TwoRandomDistinctValues(min, max int) (int, int, error) {
 
 func IsSorted(s []*mariv2.KeyValuePair) bool {
 	for i := 1; i < len(s); i++ {
-		if bytes.Compare(s[i - 1].Key, s[i].Key) > 0 { return false }
+		if bytes.Compare(s[i-1].Key, s[i].Key) > 0 {
+			return false
+		}
 	}
 
 	return true
 }
 
-func Chunk (array[]KeyVal, chunkSize int) ([][]KeyVal, error) {
-	if chunkSize <= 0 { return nil, errors.New("chunk size needs to be greater than 0") }
-	
+func Chunk(array []KeyVal, chunkSize int) ([][]KeyVal, error) {
+	if chunkSize <= 0 {
+		return nil, errors.New("chunk size needs to be greater than 0")
+	}
+
 	var chunks [][]KeyVal
-	
-	if (len(array) <= chunkSize) { 
+
+	if len(array) <= chunkSize {
 		return append(chunks, array), nil
 	} else {
 		totalChunks := (len(array) / chunkSize) + 1
 
-		for idx := range make([]int, totalChunks - 1) {
+		for idx := range make([]int, totalChunks-1) {
 			start := idx * chunkSize
 			end := (idx + 1) * chunkSize
 			chunks = append(chunks, array[start:end])
 		}
 
 		startOfRemainder := (totalChunks - 1) * chunkSize
-		
-		if startOfRemainder < len(array) { return append(chunks, array[startOfRemainder:]), nil }
+
+		if startOfRemainder < len(array) {
+			return append(chunks, array[startOfRemainder:]), nil
+		}
 		return chunks, nil
-	} 
+	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -8,46 +8,55 @@ import (
 	"unsafe"
 )
 
-
 //============================================= Mari Transaction
 
-
 // newTx
+//
 //	Creates a new transaction.
 //	The current root is operated on for "Optimistic Concurrency Control".
 //	If isWrite is false, then write operations in the read only transaction will fail.
 func newTx(mariInst *Mari, rootPtr *unsafe.Pointer, isWrite bool) *Tx {
-	return &Tx{ store: mariInst, root: rootPtr, isWrite: isWrite }
+	return &Tx{store: mariInst, root: rootPtr, isWrite: isWrite}
 }
 
 // ReadTx
+//
 //	Handles all read related operations.
 //	It gets the latest version of the ordered array mapped trie and starts from that offset in the mem-map.
 //	Get is concurrent since it will perform the operation on an existing path, so new paths can be written at the same time with new versions.
 func (mariInst *Mari) ReadTx(txOps func(tx *Tx) error) error {
 	var readTxErr error
-	for atomic.LoadUint32(&mariInst.isResizing) == 1 { runtime.Gosched() }
-	
+	for atomic.LoadUint32(&mariInst.isResizing) == 1 {
+		runtime.Gosched()
+	}
+
 	mariInst.rwResizeLock.RLock()
 	defer mariInst.rwResizeLock.RUnlock()
 
 	var rootOffset uint64
 	_, rootOffset, readTxErr = mariInst.loadMetaRootOffset()
-	if readTxErr != nil { return readTxErr }
+	if readTxErr != nil {
+		return readTxErr
+	}
 
 	var currRoot *INode
 	currRoot, readTxErr = mariInst.readINodeFromMemMap(rootOffset)
-	if readTxErr != nil { return readTxErr }
+	if readTxErr != nil {
+		return readTxErr
+	}
 
 	rootPtr := storeINodeAsPointer(currRoot)
 	transaction := newTx(mariInst, rootPtr, false)
 	readTxErr = txOps(transaction)
-	if readTxErr != nil { return readTxErr }
+	if readTxErr != nil {
+		return readTxErr
+	}
 
 	return nil
 }
 
 // UpdateTx
+//
 //	Handles all read-write related operations.
 //	If the operation fails, the copied and modified path is discarded and the operation retries back at the root until completed.
 //	The operation begins at the latest known version of root, reads from the metadata in the memory map.
@@ -60,28 +69,36 @@ func (mariInst *Mari) UpdateTx(txOps func(tx *Tx) error) error {
 	var versionPtr *uint64
 
 	for {
-		for atomic.LoadUint32(&mariInst.isResizing) == 1 { runtime.Gosched() }
+		for atomic.LoadUint32(&mariInst.isResizing) == 1 {
+			runtime.Gosched()
+		}
 		mariInst.rwResizeLock.RLock()
 
 		versionPtr, version, updateTxErr = mariInst.loadMetaVersion()
-		if updateTxErr != nil { return updateTxErr }
+		if updateTxErr != nil {
+			return updateTxErr
+		}
 
 		if version == atomic.LoadUint64(versionPtr) {
 			_, rootOffset, updateTxErr = mariInst.loadMetaRootOffset()
-			if updateTxErr != nil { return updateTxErr }
-	
+			if updateTxErr != nil {
+				return updateTxErr
+			}
+
 			currRoot, updateTxErr = mariInst.readINodeFromMemMap(rootOffset)
 			if updateTxErr != nil {
 				mariInst.rwResizeLock.RUnlock()
 				return updateTxErr
 			}
-	
+
 			currRoot.version = currRoot.version + 1
 			rootPtr := storeINodeAsPointer(currRoot)
-			
+
 			transaction := newTx(mariInst, rootPtr, true)
 			updateTxErr = txOps(transaction)
-			if updateTxErr != nil { return updateTxErr }
+			if updateTxErr != nil {
+				return updateTxErr
+			}
 
 			updatedRootCopy = loadINodeFromPointer(rootPtr)
 			ok, updateTxErr := mariInst.exclusiveWriteMmap(updatedRootCopy)
@@ -91,7 +108,7 @@ func (mariInst *Mari) UpdateTx(txOps func(tx *Tx) error) error {
 			}
 
 			if ok {
-				mariInst.rwResizeLock.RUnlock() 
+				mariInst.rwResizeLock.RUnlock()
 				return nil
 			}
 		}
@@ -101,84 +118,113 @@ func (mariInst *Mari) UpdateTx(txOps func(tx *Tx) error) error {
 	}
 }
 
-// Put 
+// Put
+//
 //	Inserts or updates key-value pair into the ordered array mapped trie.
 //	The operation begins at the root of the trie and traverses through the tree until the correct location is found, copying the entire path.
 func (tx *Tx) Put(key, value []byte) error {
-	if ! tx.isWrite { return errors.New("attempting to perform a write in a read only transaction, use tx.UpdateTx") }
+	if !tx.isWrite {
+		return errors.New("attempting to perform a write in a read only transaction, use tx.UpdateTx")
+	}
 
 	_, putErr := tx.store.putRecursive(tx.root, key, value, 0)
-	if putErr != nil { return putErr }
+	if putErr != nil {
+		return putErr
+	}
 	return nil
 }
 
 // Get
+//
 //	Attempts to retrieve the value for a key within the ordered array mapped trie.
 //	The operation begins at the root of the trie and traverses down the path to the key.
 func (tx *Tx) Get(key []byte, transform *Transform) (*KeyValuePair, error) {
 	var newTransform Transform
 	if transform != nil {
 		newTransform = *transform
-	} else { newTransform = func(kvPair *KeyValuePair) *KeyValuePair { return kvPair } }
+	} else {
+		newTransform = func(kvPair *KeyValuePair) *KeyValuePair { return kvPair }
+	}
 
 	return tx.store.getRecursive(tx.root, key, 0, newTransform)
 }
 
-// Delete 
+// Delete
+//
 //	Attempts to delete a key-value pair within the ordered array mapped trie.
 //	It starts at the root of the trie and recurses down the path to the key to be deleted.
 //	The operation creates an entire, in-memory copy of the path down to the key.
 func (tx *Tx) Delete(key []byte) error {
-	if ! tx.isWrite { return errors.New("attempting to perform a write in a read only transaction, use tx.UpdateTx") }
+	if !tx.isWrite {
+		return errors.New("attempting to perform a write in a read only transaction, use tx.UpdateTx")
+	}
 
 	_, delErr := tx.store.deleteRecursive(tx.root, key, 0)
-	if delErr != nil { return delErr }
+	if delErr != nil {
+		return delErr
+	}
 	return nil
 }
 
 // Iterate
+//
 //	Creates an ordered iterator starting at the given start key up to the range specified by total results.
 //	Since the array mapped trie is sorted, the iterate function starts at the startKey and recursively builds the result set up the specified end.
 //	A minimum version can be provided which will limit results to the min version forward.
 //	If nil is passed for the minimum version, the earliest version in the structure will be used.
-// 	If nil is passed for the transformer, then the kv pair will be returned as is.
+//	If nil is passed for the transformer, then the kv pair will be returned as is.
 func (tx *Tx) Iterate(startKey []byte, totalResults int, opts *RangeOpts) ([]*KeyValuePair, error) {
-	var minV uint64 
+	var minV uint64
 	var transform Transform
 	if opts != nil && opts.MinVersion != nil {
 		minV = *opts.MinVersion
-	} else { minV = 0 }
+	} else {
+		minV = 0
+	}
 
 	if opts != nil && opts.Transform != nil {
 		transform = *opts.Transform
-	} else { transform = func(kvPair *KeyValuePair) *KeyValuePair { return kvPair } }
+	} else {
+		transform = func(kvPair *KeyValuePair) *KeyValuePair { return kvPair }
+	}
 
 	kvPairs, iterErr := tx.store.iterateRecursive(tx.root, minV, startKey, totalResults, 0, []*KeyValuePair{}, transform)
-	if iterErr != nil { return nil, iterErr }
+	if iterErr != nil {
+		return nil, iterErr
+	}
 	return kvPairs, nil
 }
 
 // Range
+//
 //	Since the array mapped trie is sorted by nature, the range operation begins at the root of the trie.
 //	It checks the root bitmap and determines which indexes to check in the range.
 //	It then recursively checks each index, traversing the paths and building the sorted results.
 //	A minimum version can be provided which will limit results to the min version forward.
 //	If nil is passed for the minimum version, the earliest version in the structure will be used.
-// 	If nil is passed for the transformer, then the kv pair will be returned as is.
+//	If nil is passed for the transformer, then the kv pair will be returned as is.
 func (tx *Tx) Range(startKey, endKey []byte, opts *RangeOpts) ([]*KeyValuePair, error) {
-	if bytes.Compare(startKey, endKey) == 1 { return nil, errors.New("start key is larger than end key") }
+	if bytes.Compare(startKey, endKey) == 1 {
+		return nil, errors.New("start key is larger than end key")
+	}
 
-	var minV uint64 
+	var minV uint64
 	var transform Transform
 	if opts != nil && opts.MinVersion != nil {
 		minV = *opts.MinVersion
-	} else { minV = 0 }
+	} else {
+		minV = 0
+	}
 
 	if opts != nil && opts.Transform != nil {
 		transform = *opts.Transform
-	} else { transform = func(kvPair *KeyValuePair) *KeyValuePair { return kvPair } }
+	} else {
+		transform = func(kvPair *KeyValuePair) *KeyValuePair { return kvPair }
+	}
 
 	kvPairs, rangeErr := tx.store.rangeRecursive(tx.root, minV, startKey, endKey, 0, transform)
-	if rangeErr != nil { return nil, rangeErr }
+	if rangeErr != nil {
+		return nil, rangeErr
+	}
 	return kvPairs, nil
 }

--- a/types.go
+++ b/types.go
@@ -7,7 +7,6 @@ import (
 	"unsafe"
 )
 
-
 // MMap is the byte array representation of the memory mapped file in memory.
 type MMap []byte
 
@@ -156,7 +155,8 @@ var DefaultPageSize = os.Getpagesize()
 
 // DefaultNodePoolSize is the max number of nodes in the node pool, and the pre-allocated node pool size
 const DefaultNodePoolSize = int64(1000000)
-//	MaxCompactVersion is the maximum default version to increment to before the compaction process
+
+// MaxCompactVersion is the maximum default version to increment to before the compaction process
 const MaxCompactVersion = uint64(1000000)
 
 const (

--- a/utils.go
+++ b/utils.go
@@ -5,33 +5,40 @@ import (
 	"math/bits"
 )
 
-
 //============================================= Mari Utilities
 
-
 // Print children
+//
 //	Debugging function for printing nodes in the ordered array mapped trie.
 func (mariInst *Mari) PrintChildren() error {
 	_, rootOffset, readRootOffErr := mariInst.loadMetaRootOffset()
-	if readRootOffErr != nil { return readRootOffErr }
+	if readRootOffErr != nil {
+		return readRootOffErr
+	}
 
 	currRoot, readRootErr := mariInst.readINodeFromMemMap(rootOffset)
-	if readRootErr != nil { return readRootErr }
-	
+	if readRootErr != nil {
+		return readRootErr
+	}
+
 	totalCount, readChildrenErr := mariInst.printChildrenRecursive(currRoot, 0, 0)
-	if readChildrenErr != nil { return readChildrenErr }
+	if readChildrenErr != nil {
+		return readChildrenErr
+	}
 
 	fmt.Println("total count of elements:", totalCount)
 	return nil
 }
 
 // calculateHammingWeight
+//
 //	Determines the total number of 1s in the binary representation of a number. 0s are ignored.
 func calculateHammingWeight(bitmap uint32) int {
 	return bits.OnesCount32(bitmap)
 }
 
 // extendTable
+//
 //	Utility function for dynamically expanding the child node array if a bit is set and a value needs to be inserted into the array.
 func extendTable(orig []*INode, bitmap [8]uint32, pos int, newNode *INode) []*INode {
 	tableSize := populationCount(bitmap)
@@ -39,73 +46,77 @@ func extendTable(orig []*INode, bitmap [8]uint32, pos int, newNode *INode) []*IN
 
 	copy(newTable[:pos], orig[:pos])
 	newTable[pos] = newNode
-	copy(newTable[pos + 1:], orig[pos:])
-	
+	copy(newTable[pos+1:], orig[pos:])
+
 	return newTable
 }
 
 // getIndexForLevel
+//
 //	Determines the local level for a key.
 func getIndexForLevel(key []byte, level int) byte {
 	return key[level]
 }
 
 // getPosition
+//
 //	Calculates the position in the child node array based on the sparse index and the current bitmap of internal node.
 //	The sparse index is calculated using the hash and bitchunk size.
 //	A mask is calculated by performing a bitwise left shift operation, which shifts the binary representation of the value 1 the number of positions associated with the sparse index value and then subtracts 1.
 //	This creates a binary number with all 1s to the right sparse index positions.
-//	The mask is then applied the bitmap and the resulting isolated bits are the 1s right of the sparse index. 
+//	The mask is then applied the bitmap and the resulting isolated bits are the 1s right of the sparse index.
 //	The hamming weight, or total bits right of the sparse index, is then calculated.
 func getPosition(bitMap [8]uint32, index byte, level int) int {
 	subBitmapIndex := index >> 5
 	indexInSubBitmap := index & 0x1F
 	precedingSubBitmapsCount := 0
-	
-	if subBitmapIndex - 1 > 0 {
+
+	if subBitmapIndex-1 > 0 {
 		switch subBitmapIndex - 1 {
-			case 6:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[6])
-				fallthrough
-			case 5:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[5])
-				fallthrough
-			case 4:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[4])
-				fallthrough
-			case 3:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[3])
-				fallthrough
-			case 2:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[2])
-				fallthrough
-			case 1:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[1])
-				fallthrough
-			case 0:
-				precedingSubBitmapsCount += calculateHammingWeight(bitMap[0])
+		case 6:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[6])
+			fallthrough
+		case 5:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[5])
+			fallthrough
+		case 4:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[4])
+			fallthrough
+		case 3:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[3])
+			fallthrough
+		case 2:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[2])
+			fallthrough
+		case 1:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[1])
+			fallthrough
+		case 0:
+			precedingSubBitmapsCount += calculateHammingWeight(bitMap[0])
 		}
 	}
 
 	subBitmap := bitMap[subBitmapIndex]
 	mask := uint32((1 << uint32(indexInSubBitmap)) - 1)
 	isolatedBits := subBitmap & mask
-	
+
 	return precedingSubBitmapsCount + calculateHammingWeight(isolatedBits)
 }
 
 // isBitSet
+//
 //	Determines whether or not a bit is set in a bitmap by taking the bitmap and applying a mask with a 1 at the position in the bitmap to check.
 //	A logical and operation is applied and if the value is not equal to 0, then the bit is set.
 func isBitSet(bitmap [8]uint32, index byte) bool {
 	subBitmapIndex := index >> 5
-	indexInSubBitmap := index & 0x1F 
+	indexInSubBitmap := index & 0x1F
 
 	subBitmap := bitmap[subBitmapIndex]
 	return (subBitmap & (1 << indexInSubBitmap)) != 0
 }
 
 // populationCount
+//
 //	Determine the total population for the combination of all 8 32 bit bitmaps making up the 256 bit bitmap.
 func populationCount(bitmap [8]uint32) int {
 	popCount := 0
@@ -123,18 +134,20 @@ func populationCount(bitmap [8]uint32) int {
 }
 
 // setBit
+//
 //	Performs a logical xor operation on the current bitmap and the a 32 bit value where the value is all 0s except for at the position of the incoming index.
-//	Essentially flips the bit if incoming is 1 and bitmap is 0 at that position, or 0 to 1. 
+//	Essentially flips the bit if incoming is 1 and bitmap is 0 at that position, or 0 to 1.
 //	If 0 and 0 or 1 and 1, bitmap is not changed.
 func setBit(bitmap [8]uint32, index byte) [8]uint32 {
 	subBitmapIndex := index >> 5
-	indexInSubBitmap := index & 0x1F 
+	indexInSubBitmap := index & 0x1F
 
 	bitmap[subBitmapIndex] = bitmap[subBitmapIndex] ^ (1 << indexInSubBitmap)
 	return bitmap
 }
 
 // shrinkTable
+//
 //	Inverse of the extendTable utility function.
 //	It dynamically shrinks a table by removing an element at a given position.
 func shrinkTable(orig []*INode, bitmap [8]uint32, pos int) []*INode {
@@ -142,27 +155,36 @@ func shrinkTable(orig []*INode, bitmap [8]uint32, pos int) []*INode {
 	newTable := make([]*INode, tableSize)
 
 	copy(newTable[:pos], orig[:pos])
-	copy(newTable[pos:], orig[pos + 1:])
-	
+	copy(newTable[pos:], orig[pos+1:])
+
 	return newTable
 }
 
 // printChildrenRecursive
+//
 //	Recursively print nodes in the mariInst as we traverse down levels.
 func (mariInst *Mari) printChildrenRecursive(node *INode, totalCount, level int) (int, error) {
-	if node == nil { return 0, nil }
+	if node == nil {
+		return 0, nil
+	}
 
 	for idx := range node.children {
 		childPtr := node.children[idx]
 		child, desErr := mariInst.readINodeFromMemMap(childPtr.startOffset)
-		if desErr != nil { return 0, desErr }
+		if desErr != nil {
+			return 0, desErr
+		}
 
 		if child != nil {
-			if len(child.leaf.key) > 0 { totalCount += 1 }
+			if len(child.leaf.key) > 0 {
+				totalCount += 1
+			}
 
-			fmt.Printf("Level: %d, Index: %d, Key: %s, Value: %s, Version:%d\n", level + 1, idx, child.leaf.key, child.leaf.value, child.leaf.version)
-			newtotalCount, printErr := mariInst.printChildrenRecursive(child, totalCount, level + 1)
-			if printErr != nil { return 0, printErr }
+			fmt.Printf("Level: %d, Index: %d, Key: %s, Value: %s, Version:%d\n", level+1, idx, child.leaf.key, child.leaf.value, child.leaf.version)
+			newtotalCount, printErr := mariInst.printChildrenRecursive(child, totalCount, level+1)
+			if printErr != nil {
+				return 0, printErr
+			}
 
 			totalCount = newtotalCount
 		}


### PR DESCRIPTION
I simply went through the files and saved with gofmt'ing on. This keeps the files in a relatively standard format.

resolves #2 